### PR TITLE
Display AD Login Info Not Static String

### DIFF
--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -127,7 +127,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
 
       UserInfo aadUser = result.getUserInfo();
       UserIdentity.Builder userIdentityBuilder = UserIdentity.builder()
-        .setProviderLogin(getName())
+        .setProviderLogin(aadUser.getDisplayableId())
         .setLogin(getLogin(aadUser))
         .setName(aadUser.getGivenName() + " " + aadUser.getFamilyName())
         .setEmail(aadUser.getDisplayableId());


### PR DESCRIPTION
Rather than displaying the string “Azure AD” for all users with connections to AAD, set the “Provider Login” value to the Displayable ID from the AD info. Fixes the new requirement for a unique value in SonarQube 7.2 and makes it easier to see what AD account is associated with a specific SQ user.

Fixes #45 