### PR TITLE
Add Azure Regions

### DIFF
--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -173,9 +173,8 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
       do {
     	  URL url = getUrl(userId, nextPage);
 	      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-	      connection.setRequestProperty("api-version", "1.6");
 	      connection.setRequestProperty("Authorization", accessToken);
-	      connection.setRequestProperty("Accept", "application/json;odata=minimalmetadata");
+	      connection.setRequestProperty("Accept", "application/json;odata.metadata=minimal");
 	      String goodRespStr = HttpClientHelper.getResponseStringFromConn(connection, true);
 	      int responseCode = connection.getResponseCode();
 	      JSONObject response = HttpClientHelper.processGoodRespStr(responseCode, goodRespStr);

--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -55,10 +55,8 @@ import org.sonar.api.utils.log.Loggers;
 
 import static java.lang.String.format;
 import static org.almrangers.auth.aad.AadSettings.AUTH_REQUEST_FORMAT;
-import static org.almrangers.auth.aad.AadSettings.GROUPS_REQUEST_FORMAT;
 import static org.almrangers.auth.aad.AadSettings.LOGIN_STRATEGY_PROVIDER_ID;
 import static org.almrangers.auth.aad.AadSettings.LOGIN_STRATEGY_UNIQUE;
-import static org.almrangers.auth.aad.AadSettings.SECURE_RESOURCE_URL;
 
 @ServerSide
 public class AadIdentityProvider implements OAuth2IdentityProvider {
@@ -122,7 +120,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
       URI url = new URI(context.getCallbackUrl());
       ClientCredential clientCredt = new ClientCredential(settings.clientId(), settings.clientSecret());
       Future<AuthenticationResult> future = authContext.acquireTokenByAuthorizationCode(
-        oAuthVerifier, url, clientCredt, SECURE_RESOURCE_URL, null);
+        oAuthVerifier, url, clientCredt, settings.getGraphURL(), null);
       result = future.get();
 
       UserInfo aadUser = result.getUserInfo();
@@ -158,7 +156,7 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
   }
 
   URL getUrl(String userId, String nextPage) throws MalformedURLException {
-	  String url =  String.format(GROUPS_REQUEST_FORMAT, settings.tenantId(), userId);
+	  String url =  String.format(settings.getGraphMembershipUrl(), settings.tenantId(), userId);
 	  // Append odata query parameters for subsequent pages
 	if (null != nextPage) {
 		url += "&" + nextPage;

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -62,7 +62,7 @@ public class AadSettings {
   protected static final String SECURE_RESOURCE_URL = "https://graph.microsoft.com";
 
   protected static final String AUTH_REQUEST_FORMAT = "%s?client_id=%s&response_type=code&redirect_uri=%s&state=%s&scope=openid";
-  protected static final String GROUPS_REQUEST_FORMAT = "https://graph.microsoft.com/v1.0/%s/users/%s/memberOf";
+  protected static final String GROUPS_REQUEST_FORMAT = "/v1.0/%s/users/%s/memberOf";
 
   private final Settings settings;
 
@@ -187,6 +187,14 @@ public class AadSettings {
 
   public String authorityUrl() {
     return String.format("%s/%s/%s", ROOT_URL, getEndpoint(), AUTHORITY_URL);
+  }
+
+  public String getGraphURL() {
+    return SECURE_RESOURCE_URL;
+  }
+
+  public String getGraphMembershipUrl() {
+    return getGraphURL() + GROUPS_REQUEST_FORMAT;
   }
 
   public String loginStrategy() {

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -59,10 +59,10 @@ public class AadSettings {
   protected static final String AUTHORIZATION_URL = "oauth2/authorize";
   protected static final String AUTHORITY_URL = "oauth2/token";
   protected static final String COMMON_URL = "common";
-  protected static final String SECURE_RESOURCE_URL = "https://graph.windows.net";
+  protected static final String SECURE_RESOURCE_URL = "https://graph.microsoft.com";
 
   protected static final String AUTH_REQUEST_FORMAT = "%s?client_id=%s&response_type=code&redirect_uri=%s&state=%s&scope=openid";
-  protected static final String GROUPS_REQUEST_FORMAT = "https://graph.windows.net/%s/users/%s/memberOf?api-version=1.6";
+  protected static final String GROUPS_REQUEST_FORMAT = "https://graph.microsoft.com/v1.0/%s/users/%s/memberOf";
 
   private final Settings settings;
 

--- a/src/main/java/org/almrangers/auth/aad/AadSettings.java
+++ b/src/main/java/org/almrangers/auth/aad/AadSettings.java
@@ -44,6 +44,11 @@ public class AadSettings {
   protected static final String ENABLED = "sonar.auth.aad.enabled";
   protected static final String ALLOW_USERS_TO_SIGN_UP = "sonar.auth.aad.allowUsersToSignUp";
   protected static final String TENANT_ID = "sonar.auth.aad.tenantId";
+  protected static final String DIRECTORY_LOCATION = "sonar.auth.aad.directoryLocation";
+  protected static final String DIRECTORY_LOC_GLOBAL = "Azure AD (Global)";
+  protected static final String DIRECTORY_LOC_USGOV = "Azure AD for US Government";
+  protected static final String DIRECTORY_LOC_DE = "Azure AD for Germany";
+  protected static final String DIRECTORY_LOC_CN = "Azure AD China";
   protected static final String ENABLE_GROUPS_SYNC = "sonar.auth.aad.enableGroupsSync";
   protected static final String LOGIN_STRATEGY = "sonar.auth.aad.loginStrategy";
   protected static final String LOGIN_STRATEGY_UNIQUE = "Unique";
@@ -55,12 +60,18 @@ public class AadSettings {
   protected static final String SUBCATEGORY = "Authentication";
   protected static final String GROUPSYNCSUBCATEGORY = "Groups Synchronization";
 
-  protected static final String ROOT_URL = "https://login.microsoftonline.com";
+  protected static final String LOGIN_URL = "https://login.microsoftonline.com";
+  protected static final String LOGIN_URL_USGOV = "https://login.microsoftonline.us";
+  protected static final String LOGIN_URL_DE = "https://login.microsoftonline.de";
+  protected static final String LOGIN_URL_CN = "https://login.chinacloudapi.cn";
   protected static final String AUTHORIZATION_URL = "oauth2/authorize";
   protected static final String AUTHORITY_URL = "oauth2/token";
   protected static final String COMMON_URL = "common";
-  protected static final String SECURE_RESOURCE_URL = "https://graph.microsoft.com";
 
+  protected static final String GRAPH_URL = "https://graph.microsoft.com";
+  protected static final String GRAPH_URL_USGOV = "https://graph.microsoft.com";
+  protected static final String GRAPH_URL_DE = "https://graph.microsoft.de";
+  protected static final String GRAPH_URL_CN = "https://microsoftgraph.chinacloudapi.cn";
   protected static final String AUTH_REQUEST_FORMAT = "%s?client_id=%s&response_type=code&redirect_uri=%s&state=%s&scope=openid";
   protected static final String GROUPS_REQUEST_FORMAT = "/v1.0/%s/users/%s/memberOf";
 
@@ -132,6 +143,16 @@ public class AadSettings {
         .options(LOGIN_STRATEGY_UNIQUE, LOGIN_STRATEGY_PROVIDER_ID)
         .index(7)
         .build(),
+      PropertyDefinition.builder(DIRECTORY_LOCATION)
+        .name("Directory Location")
+        .description("The location of the Azure installation. You normally won't need to change this.")
+        .category(CATEGORY)
+        .subCategory(SUBCATEGORY)
+        .type(SINGLE_SELECT_LIST)
+        .defaultValue(DIRECTORY_LOC_GLOBAL)
+        .options(DIRECTORY_LOC_GLOBAL, DIRECTORY_LOC_USGOV, DIRECTORY_LOC_DE, DIRECTORY_LOC_CN)
+        .index(8)
+        .build(),
       PropertyDefinition.builder(ENABLE_GROUPS_SYNC)
         .name("Enable Groups Synchronization")
         .description("Enable groups synchronization from Azure AD to SonarQube, For each Azure AD group user belongs to, the user will be associated to a group with the same name(if it exists) in SonarQube.")
@@ -139,7 +160,7 @@ public class AadSettings {
         .subCategory(GROUPSYNCSUBCATEGORY)
         .type(BOOLEAN)
         .defaultValue(valueOf(false))
-        .index(8)
+        .index(9)
         .build()
 
     );
@@ -181,16 +202,50 @@ public class AadSettings {
     }
   }
 
+  private String getLoginHost() {
+    String directoryLocation = settings.getString(DIRECTORY_LOCATION);
+
+    switch (directoryLocation) {
+      case DIRECTORY_LOC_USGOV:
+        return LOGIN_URL_USGOV;
+
+      case DIRECTORY_LOC_DE:
+        return LOGIN_URL_DE;
+
+      case DIRECTORY_LOC_CN:
+        return LOGIN_URL_CN;
+
+      case DIRECTORY_LOC_GLOBAL:
+      default:
+        return LOGIN_URL;
+    }
+  }
+
   public String authorizationUrl() {
-    return String.format("%s/%s/%s", ROOT_URL, getEndpoint(), AUTHORIZATION_URL);
+    return String.format("%s/%s/%s", getLoginHost(), getEndpoint(), AUTHORIZATION_URL);
   }
 
   public String authorityUrl() {
-    return String.format("%s/%s/%s", ROOT_URL, getEndpoint(), AUTHORITY_URL);
+    return String.format("%s/%s/%s", getLoginHost(), getEndpoint(), AUTHORITY_URL);
   }
 
   public String getGraphURL() {
-    return SECURE_RESOURCE_URL;
+    String directoryLocation = settings.getString(DIRECTORY_LOCATION);
+
+    switch (directoryLocation) {
+      case DIRECTORY_LOC_USGOV:
+        return GRAPH_URL_USGOV;
+
+      case DIRECTORY_LOC_DE:
+        return GRAPH_URL_DE;
+
+      case DIRECTORY_LOC_CN:
+        return GRAPH_URL_CN;
+
+      case DIRECTORY_LOC_GLOBAL:
+      default:
+        return GRAPH_URL;
+    }
   }
 
   public String getGraphMembershipUrl() {

--- a/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadIdentityProviderTest.java
@@ -128,6 +128,7 @@ public class AadIdentityProviderTest {
       settings.setProperty("sonar.auth.aad.clientId.secured", "id");
       settings.setProperty("sonar.auth.aad.clientSecret.secured", "secret");
       settings.setProperty("sonar.auth.aad.loginStrategy", AadSettings.LOGIN_STRATEGY_DEFAULT_VALUE);
+      settings.setProperty("sonar.auth.aad.directoryLocation", AadSettings.DIRECTORY_LOC_GLOBAL);
       settings.setProperty("sonar.auth.aad.enabled", true);
     } else {
       settings.setProperty("sonar.auth.aad.enabled", false);

--- a/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AadSettingsTest.java
@@ -31,7 +31,7 @@ import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
 import org.sonar.api.config.internal.MapSettings;
 
-import static org.almrangers.auth.aad.AadSettings.LOGIN_STRATEGY_DEFAULT_VALUE;
+import static org.almrangers.auth.aad.AadSettings.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AadSettingsTest {
@@ -63,6 +63,29 @@ public class AadSettingsTest {
   public void return_authorization_url_for_multi_tenant_azureAd_app() {
     settings.setProperty("sonar.auth.aad.multiTenant", "true");
     assertThat(underTest.authorizationUrl()).isEqualTo("https://login.microsoftonline.com/common/oauth2/authorize");
+  }
+
+  @Test
+  public void return_correct_urls() {
+    //Azure Default "Global"
+    settings.setProperty("sonar.auth.aad.directoryLocation", DIRECTORY_LOC_GLOBAL);
+    assertThat(underTest.authorizationUrl().startsWith("https://login.microsoftonline.com"));
+    assertThat(underTest.getGraphURL().startsWith("https://graph.microsoft.com"));
+
+    //Azure US Gov
+    settings.setProperty("sonar.auth.aad.directoryLocation", DIRECTORY_LOC_USGOV);
+    assertThat(underTest.authorizationUrl().startsWith("https://login.microsoftonline.us"));
+    assertThat(underTest.getGraphURL().startsWith("https://graph.microsoft.com"));
+
+    //Azure Germany
+    settings.setProperty("sonar.auth.aad.directoryLocation", DIRECTORY_LOC_DE);
+    assertThat(underTest.authorizationUrl().startsWith("https://login.microsoftonline.de"));
+    assertThat(underTest.getGraphURL().startsWith("https://graph.microsoft.de"));
+
+    //Azure China
+    settings.setProperty("sonar.auth.aad.directoryLocation", DIRECTORY_LOC_CN);
+    assertThat(underTest.authorizationUrl().startsWith("https://login.chinacloudapi.cn"));
+    assertThat(underTest.getGraphURL().startsWith("https://microsoftgraph.chinacloudapi.cn"));
   }
 
   @Test
@@ -113,7 +136,7 @@ public class AadSettingsTest {
 
   @Test
   public void definitions() {
-    assertThat(AadSettings.definitions()).hasSize(8);
+    assertThat(AadSettings.definitions()).hasSize(9);
   }
 
 }

--- a/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
+++ b/src/test/java/org/almrangers/auth/aad/AuthAadPluginTest.java
@@ -35,7 +35,7 @@ public class AuthAadPluginTest {
 
   @Test
   public void test_extensions() {
-    assertThat(underTest.getExtensions()).hasSize(10);
+    assertThat(underTest.getExtensions()).hasSize(11);
   }
 
 }


### PR DESCRIPTION
These commits add the ability to select from one of Microsoft's Azure National Clouds for authentication. It also migrates from the Azure Graph API to the Microsoft Graph API to support all the regions.

The endpoint URLs for login and graph were gathered from https://developer.microsoft.com/en-us/graph/docs/concepts/deployments.

Testing was done as best as possible, but I don't have any accounts in the national clouds to fully verify the flow works 100%.

Fixes #43